### PR TITLE
修复“外接显示器手势路径错位，屏幕右侧区域窗口元素无法点击”的问题

### DIFF
--- a/MacGesture/CanvasWindowController.m
+++ b/MacGesture/CanvasWindowController.m
@@ -59,6 +59,10 @@
         for (NSScreen * screen in screens) {
             if (NSPointInRect(point, [screen frame])) {
                 [self.window setFrame:[screen frame] display:NO];
+                NSRect curFrame = [screen frame];
+                curFrame.origin.x = 0;
+                curFrame.origin.y = 0;
+                [(CanvasView *) self.window.contentView resizeTo:curFrame];
                 break;
             }
         }
@@ -81,8 +85,12 @@
 - (void)handleScreenParametersChange:(NSNotification *)notification {
     NSRect frame = NSScreen.mainScreen.frame;
     [self.window setFrame:frame display:NO];
+    frame.origin.x = 0;
+    frame.origin.y = 0;
     [(CanvasView *) self.window.contentView resizeTo:frame];
 }
+
+
 
 - (void)writeDirection:(NSString *)directionStr; {
     [(CanvasView *) self.window.contentView writeDirection:directionStr];


### PR DESCRIPTION
外接显示器的时候，有时候会出现：在外接显示器上，右键画出手势不会在绘画的地方显示手势路径，而是在屏幕最右侧显示路径，而且最右侧部分此时鼠标左键点击会自动绘制一条直线路径，在这个区域中的所有窗口元素都无法点击。

出现这个bug的原因是：窗口焦点切换的时候MacGesture会重新定位self.window.contentView，以保证该view始终在当前活动的window上，但是这个定位过程有bug，坐标设置错误。

这个补丁修复了这个问题，我已经使用了一两个月的时间，一切正常。