### PR TITLE
Fix markdown escaping issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ The following table covers probably the most basic scenario of usage:
 
 | Gesture | Filter             | Action   | Note     | Trigger on every match |
 | :-----: | :----------------- | :------: | :------: | :--------------------- |
-| `D`     | `*safari|*chrome`  |    ⌘T    | New Tab  | –                      |
-| `DR`    | `*safari|*chrome`  |    ⌘W    | Close    | –                      |
+| `D`     | `*safari\|*chrome` |    ⌘T    | New Tab  | –                      |
+| `DR`    | `*safari\|*chrome` |    ⌘W    | Close    | –                      |
 
 By setting these rules, you can empower mouse gestures to open new and close currently focused tabs in Sarari and Chrome Browsers. Simply:
 
@@ -93,8 +93,8 @@ So by defining the following rules:
 
 | Gesture | Filter             | Action   | Note     | Trigger on every match |
 | :-----: | :----------------- | :------: | :------: | :--------------------- |
-| `U*u`   | `*safari|*chrome`  |   ⇧⌘[    | Prev Tab | –                |
-| `U*d`   | `*safari|*chrome`  |   ⇧⌘]    | Next Tab | –                |
+| `U*u`   | `*safari\|*chrome` |   ⇧⌘\[   | Prev Tab | –                      |
+| `U*d`   | `*safari\|*chrome` |   ⇧⌘\]   | Next Tab | –                      |
 
 you can simply:
 
@@ -131,13 +131,13 @@ For example, the original one:
 
 | Gesture | Filter             | Action   | Note     | Trigger on every match |
 | :-----: | :----------------- | :------: | :------: | :--------------------- |
-| `U*d`   | `*`                |   ⇧⌘]    | Next Tab | Checked                |
+| `U*d`   | `*`                |   ⇧⌘\]   | Next Tab | Checked                |
 
 Then, in order to exclude Safari, change this to:
 
 | Gesture | Filter             | Action   | Note     | Trigger on every match |
 | :-----: | :----------------- | :------: | :------: | :--------------------- |
-| `U*d`   | `*|!*safari`       |   ⇧⌘]    | Next Tab | Checked                |
+| `U*d`   | `*|!*safari`       |   ⇧⌘\]   | Next Tab | Checked                |
 
 Then you will experience the expected behaviour.
 


### PR DESCRIPTION
The markdown in the `README.md` had some errors. I have fixed the table and escaped some bracket characters.
The table used to look like this for me:
![broken table](https://user-images.githubusercontent.com/72744903/121231610-96f43580-c85e-11eb-9eba-055ce0668a71.png)